### PR TITLE
Fix costmap

### DIFF
--- a/costmap_generator/nodes/costmap_generator/points_to_costmap.cpp
+++ b/costmap_generator/nodes/costmap_generator/points_to_costmap.cpp
@@ -95,7 +95,7 @@ std::vector<std::vector<std::vector<double>>> PointsToCostmap::assignPoints2Grid
       for (auto j = -expand; j < expand; j++)
       {
         grid_map::Index index(grid_ind.x() + i, grid_ind.y() + j);
-        if (isValidInd(index))
+        if (isValidInd(index) && (i * i + j * j <= expand * expand))
         {
           vec_x_y_z[index.x()][index.y()].push_back(point.z);
         }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
障害物に対して発生するコストが矩形に広がるようになっていたため、円形に変更しました。
詳細はissueを確認してください。
<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #8

<!-- 変更の詳細 -->
## Detail
変更が軽微な場所に条件を追加しました。
int型のためpowを使わず掛け算で対応しました。

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact
状況によってこれまでよりも障害物の近くを通るようになる場合があります。

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
