### PR TITLE
Separate traffic_waypoints_array and stop_waypoints_array

### DIFF
--- a/lane_planner/include/lane_select_core.h
+++ b/lane_planner/include/lane_select_core.h
@@ -77,7 +77,7 @@ private:
   ros::Timer timer_;
 
   // subscriber
-  ros::Subscriber sub1_, sub5_, sub6_;
+  ros::Subscriber sub1_, sub4_, sub5_, sub6_;
   message_filters::Subscriber<geometry_msgs::PoseStamped> sub2_;
   message_filters::Subscriber<geometry_msgs::TwistStamped> sub3_;
   using PoseTwistSyncPolicy = message_filters::sync_policies::ApproximateTime<geometry_msgs::PoseStamped, geometry_msgs::TwistStamped>;
@@ -121,6 +121,7 @@ private:
 
   // callbacks
   void callbackFromLaneArray(const autoware_msgs::LaneArrayConstPtr& msg);
+  void callbackFromStopArray(const autoware_msgs::LaneArrayConstPtr& msg);
   void callbackFromState(const std_msgs::StringConstPtr& msg);
   void callbackFromDecisionMakerState(const std_msgs::StringConstPtr& msg);
   void callbackFromConfig(const autoware_config_msgs::ConfigLaneSelectConstPtr& msg);

--- a/lane_planner/nodes/lane_stop/lane_stop.cpp
+++ b/lane_planner/nodes/lane_stop/lane_stop.cpp
@@ -108,8 +108,8 @@ int main(int argc, char **argv)
   n.param<bool>("/lane_stop/pub_waypoint_latch", pub_waypoint_latch, true);
   n.param<bool>("/lane_stop/manual_detection", config_manual_detection, true);
 
-  traffic_pub = n.advertise<autoware_msgs::LaneArray>("traffic_waypoints_array", pub_waypoint_queue_size,
-                pub_waypoint_latch);
+  traffic_pub =
+      n.advertise<autoware_msgs::LaneArray>("stop_waypoints_array", pub_waypoint_queue_size, pub_waypoint_latch);
 
   ros::Subscriber light_sub = n.subscribe("light_color", sub_light_queue_size, receive_auto_detection);
   ros::Subscriber light_managed_sub = n.subscribe("light_color_managed", sub_light_queue_size,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
- ```lane_stop```がパブリッシュするトピック名を変更：```traffic_waypoints_array```->```stop_waypoints_array```
- ```lane_select```は```traffic_waypoints_array```を受け取ったときのみ現在位置のインデックスを初期化し、```stop_waypoints_array```を受け取ったときは経路情報のみ更新

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #12

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
