### PR TITLE
Separate avoid_waypoint_index_ and base_waypoint_index_

### DIFF
--- a/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
+++ b/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
@@ -87,14 +87,19 @@ private:
   // Index of the closest waypoint in the current_waypoints_ Lane.
   // Not the same as the waypoint gid. This value can change suddenly if the
   // current_waypoints_ switches between base_waypoints_ and avoid_waypoints_.
+  State select_way_;
   int closest_waypoint_index_ = -1;
+  int avoid_waypoint_index_ = -1;
+  int avoid_start_index_ = 0;
+  int avoid_finish_index_ = 0;
+  int base_waypoint_index_ = -1;
+  int base_avoid_index_offset_ = 0;
 
-  // Index of the obstacle relative to closest_waypoint_index_.
+  // Index of the obstacle relative to current_waypoint_index_.
   int obstacle_waypoint_index_ = -1;
   nav_msgs::OccupancyGrid costmap_;
   autoware_msgs::Lane base_waypoints_;
   autoware_msgs::Lane avoid_waypoints_;
-  autoware_msgs::Lane current_waypoints_;
   geometry_msgs::PoseStamped current_pose_local_, current_pose_global_;
   geometry_msgs::PoseStamped goal_pose_local_, goal_pose_global_;
   geometry_msgs::TwistStamped current_velocity_;
@@ -117,11 +122,13 @@ private:
   // functions
   bool checkInitialized();
   bool planAvoidWaypoints(int& end_of_avoid_index);
-  void mergeAvoidWaypoints(const nav_msgs::Path& path, int& end_of_avoid_index);
+  void mergeAvoidWaypoints(const nav_msgs::Path& path, const int start_index, const int goal_index,
+                           int& end_of_avoid_index);
   tf::Transform getTransform(const std::string& from, const std::string& to);
 
   // Find closest waypoint index within a search_size around the previous closest waypoint
-  void updateClosestWaypoint(const autoware_msgs::Lane& waypoints, const geometry_msgs::Pose& pose, const int& search_size);
+  int updateClosestWaypoint(const autoware_msgs::Lane& waypoints, const int previous_index,
+                            const geometry_msgs::Pose& pose, const int& search_size);
   // publish safety waypoints using a timer
   void publishWaypoints(const ros::TimerEvent& e);
 };

--- a/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
+++ b/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
@@ -90,10 +90,10 @@ private:
   State select_way_;
   int closest_waypoint_index_ = -1;
   int avoid_waypoint_index_ = -1;
-  int avoid_start_index_ = 0;
-  int avoid_finish_index_ = 0;
+  int avoid_start_index_ = -1;
+  int avoid_finish_index_ = -1;
   int base_waypoint_index_ = -1;
-  int base_avoid_index_offset_ = 0;
+  int base_finish_index_ = -1;
 
   // Index of the obstacle relative to current_waypoint_index_.
   int obstacle_waypoint_index_ = -1;

--- a/waypoint_planner/src/astar_avoid/astar_avoid.cpp
+++ b/waypoint_planner/src/astar_avoid/astar_avoid.cpp
@@ -328,8 +328,6 @@ bool AstarAvoid::planAvoidWaypoints(int& end_of_avoid_index)
       }
       else
       {
-        base_finish_index_ = -1;
-        avoid_waypoint_index_ = -1;
         found_path = false;
       }
     }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
※実機で動作確認後Draft解除予定
waypoint_plannerで軌跡追跡(RELAYING)と回避動作(AVOIDING)の切替時にインデックスがずれ、例外が出る問題を解消しました。
- ```AstarAvoid::run()```関数では状態遷移のみを行うように変更(```updateClosestWaypoint```を削除)
- ```AstarAvoid::publishWaypoints(const ros::TimerEvent& e)```の内部でのみ一定周期で```updateClosestWaypoint```を実行するように変更
- 現在のindexとして```closest_waypoint_index_```が使われていて、これがwaypoint切替時に探索範囲がずれる原因になっていたので、回避経路用の```avoid_waypoint_index_ ```と```base_waypoint_index_```を常に両方保持するように変更
- 例外発生時は一番近い点からRELAYINGに移行するように変更


<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #13

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
