### PR TITLE
Bugfix/lane select

### DIFF
--- a/lane_planner/nodes/lane_rule_lanelet2/lane_rule_lanelet2.cpp
+++ b/lane_planner/nodes/lane_rule_lanelet2/lane_rule_lanelet2.cpp
@@ -170,7 +170,7 @@ std::vector<size_t> check_waypoints_for_stoplines(const std::vector<Eigen::Vecto
   for (auto wp_i = waypoints.begin(); wp_i < waypoints.end() - 1; wp_i++)
   {
     lanelet::Point3d wp_p0(lanelet::utils::getId(), (*wp_i).x(), (*wp_i).y(), (*wp_i).z());
-    lanelet::Point3d wp_p1(lanelet::utils::getId(),(*(wp_i + 1)).x(), (*(wp_i + 1)).y(), (*(wp_i + 1)).z());
+    lanelet::Point3d wp_p1(lanelet::utils::getId(), (*(wp_i + 1)).x(), (*(wp_i + 1)).y(), (*(wp_i + 1)).z());
     lanelet::BasicPoint2d wp_p02((*wp_i).x(), (*wp_i).y());
     lanelet::ConstLanelets candidate_lanelets;
 
@@ -460,8 +460,8 @@ int main(int argc, char** argv)
                                                               pub_waypoint_latch);
   g_red_pub =
       rosnode.advertise<autoware_msgs::LaneArray>("red_waypoints_array", pub_waypoint_queue_size, pub_waypoint_latch);
-  g_green_pub = rosnode.advertise<autoware_msgs::LaneArray>("green_waypoints_array", pub_waypoint_queue_size,
-                                                            pub_waypoint_latch);
+  g_green_pub =
+      rosnode.advertise<autoware_msgs::LaneArray>("green_waypoints_array", pub_waypoint_queue_size, pub_waypoint_latch);
 
   ros::Subscriber bin_map_sub = rosnode.subscribe("lanelet_map_bin", 10, binMapCallback);
   ros::Subscriber waypoint_sub = rosnode.subscribe("lane_waypoints_array", sub_waypoint_queue_size, create_waypoint);

--- a/lane_planner/nodes/lane_select/lane_select_core.cpp
+++ b/lane_planner/nodes/lane_select/lane_select_core.cpp
@@ -626,11 +626,11 @@ void LaneSelectNode::publishVehicleLocation(const int32_t clst_wp, const int32_t
 // Initialize the entire waypoints by receiving traffic_waypoints_array. Receive only once at the beginning.
 void LaneSelectNode::callbackFromLaneArray(const autoware_msgs::LaneArrayConstPtr& msg)
 {
-  ROS_INFO("[LaneSelectNode::callbackFromLaneArray] Clearing lanes. lane_id = %d", msg->id);
+  ROS_INFO("[LaneSelectNode::callbackFromLaneArray] Initialize lanes. lane_id = %d", msg->id);
   tuple_vec_.clear();
   tuple_vec_.shrink_to_fit();
   tuple_vec_.reserve(msg->lanes.size());
-  for (const auto& el : msg->lanes)
+  for (const autoware_msgs::Lane& el : msg->lanes)
   {
     auto t = std::make_tuple(el, -1, ChangeFlag::unknown);
     tuple_vec_.push_back(t);
@@ -650,23 +650,39 @@ void LaneSelectNode::callbackFromStopArray(const autoware_msgs::LaneArrayConstPt
   {
     return;
   }
-  tuple_vec_.resize(msg->lanes.size());
-  int current_point = std::get<1>(tuple_vec_.at(0));
-  for (uint32_t i = 0; i < msg->lanes.size(); i++)
+  else if (lane_array_id_ != msg->id)
   {
-    auto t = std::make_tuple(msg->lanes.at(i), current_point, ChangeFlag::unknown);
-    tuple_vec_.at(i) = t;
-  }
-
-  if (lane_array_id_ != msg->id)
-  {
-    ROS_INFO("[LaneSelectNode::callbackFromStopArray] Lane_id changed, initializing. %d -> %d", lane_array_id_, msg->id);
-    is_new_lane_array_ = true;
+    ROS_WARN("[LaneSelectNode::callbackFromStopArray] Lane array changed. %d -> %d", lane_array_id_, msg->id);
+    tuple_vec_.clear();
+    tuple_vec_.shrink_to_fit();
+    tuple_vec_.reserve(msg->lanes.size());
+    for (const autoware_msgs::Lane& el : msg->lanes)
+    {
+      auto t = std::make_tuple(el, -1, ChangeFlag::unknown);
+      tuple_vec_.push_back(t);
+    }
+    lane_array_id_ = msg->id;
     current_lane_idx_ = -1;
     right_lane_idx_ = -1;
     left_lane_idx_ = -1;
+    is_new_lane_array_ = true;
+    return;
   }
-  lane_array_id_ = msg->id;
+  else
+  {
+    is_new_lane_array_ = true;
+    uint32_t lanes_size = std::min(tuple_vec_.size(), msg->lanes.size());
+    for (uint32_t i = 0; i < lanes_size; i++)
+    {
+      uint32_t waypoint_size =
+          std::min(std::get<0>(tuple_vec_.at(i)).waypoints.size(), msg->lanes.at(i).waypoints.size());
+      for (uint32_t j = 0; j < waypoint_size; j++)
+      {
+        std::get<0>(tuple_vec_.at(i)).waypoints.at(j).twist = msg->lanes.at(i).waypoints.at(j).twist;
+        std::get<0>(tuple_vec_.at(i)).waypoints.at(j).pose = msg->lanes.at(i).waypoints.at(j).pose;
+      }
+    }
+  }
 }
 
 void LaneSelectNode::callbackFromPoseTwistStamped(const geometry_msgs::PoseStampedConstPtr& pose_msg,

--- a/lane_planner/nodes/lane_select/lane_select_core.cpp
+++ b/lane_planner/nodes/lane_select/lane_select_core.cpp
@@ -648,11 +648,12 @@ void LaneSelectNode::callbackFromStopArray(const autoware_msgs::LaneArrayConstPt
 {
   if (!is_lane_array_subscribed_)
   {
+    ROS_WARN_THROTTLE(5.0, "[LaneSelectNode::callbackFromLaneArray] Waiting for traffic_waypoints_array");
     return;
   }
   else if (lane_array_id_ != msg->id)
   {
-    ROS_WARN("[LaneSelectNode::callbackFromStopArray] Lane array changed. %d -> %d", lane_array_id_, msg->id);
+    ROS_WARN("[LaneSelectNode::callbackFromStopArray] Lane id changed. %d -> %d", lane_array_id_, msg->id);
     tuple_vec_.clear();
     tuple_vec_.shrink_to_fit();
     tuple_vec_.reserve(msg->lanes.size());

--- a/lane_planner/nodes/lane_select/lane_select_core.cpp
+++ b/lane_planner/nodes/lane_select/lane_select_core.cpp
@@ -79,7 +79,7 @@ void LaneSelectNode::initForROS()
   private_nh_.param<double>("update_rate", update_rate_, double(10.0));
 
   // Kick off a timer to publish base_waypoints, closest_waypoint, change_flag, current_lane_id, and vehicle_location
-  timer_ = nh_.createTimer(ros::Duration(1.0/update_rate_), &LaneSelectNode::processing, this);
+  timer_ = nh_.createTimer(ros::Duration(1.0 / update_rate_), &LaneSelectNode::processing, this);
 }
 
 bool LaneSelectNode::isAllTopicsSubscribed()
@@ -133,7 +133,8 @@ void LaneSelectNode::processing(const ros::TimerEvent& e)
     return;
   }
 
-  if (current_lane_idx_ == -1) {
+  if (current_lane_idx_ == -1)
+  {
     // Note: Only call it after calling updateClosestWaypointNumberForEachLane()
     findCurrentLane();
   }
@@ -147,7 +148,8 @@ void LaneSelectNode::processing(const ros::TimerEvent& e)
       changeLane();
       std::get<1>(lane_for_change_) =
           getClosestWaypointNumber(std::get<0>(lane_for_change_), current_pose_.pose, current_velocity_.twist,
-                                   std::get<1>(lane_for_change_), distance_threshold_, search_closest_waypoint_minimum_dt_);
+                                   std::get<1>(lane_for_change_), distance_threshold_,
+                                   search_closest_waypoint_minimum_dt_);
       std::get<2>(lane_for_change_) = static_cast<ChangeFlag>(
           std::get<0>(lane_for_change_).waypoints.at(std::get<1>(lane_for_change_)).change_flag);
       publishLane(std::get<0>(lane_for_change_));
@@ -179,7 +181,7 @@ void LaneSelectNode::processing(const ros::TimerEvent& e)
   resetSubscriptionFlag();
 }
 
-int32_t LaneSelectNode::getClosestLaneChangeWaypointNumber(const std::vector<autoware_msgs::Waypoint> &wps,
+int32_t LaneSelectNode::getClosestLaneChangeWaypointNumber(const std::vector<autoware_msgs::Waypoint>& wps,
                                                            int32_t cl_wp)
 {
   for (uint32_t i = cl_wp; i < wps.size(); i++)
@@ -200,8 +202,8 @@ void LaneSelectNode::createLaneForChange()
   std::get<0>(lane_for_change_).waypoints.shrink_to_fit();
   std::get<1>(lane_for_change_) = -1;
 
-  const autoware_msgs::Lane &cur_lane = std::get<0>(tuple_vec_.at(current_lane_idx_));
-  const int32_t &clst_wp = std::get<1>(tuple_vec_.at(current_lane_idx_));
+  const autoware_msgs::Lane& cur_lane = std::get<0>(tuple_vec_.at(current_lane_idx_));
+  const int32_t& clst_wp = std::get<1>(tuple_vec_.at(current_lane_idx_));
 
   int32_t num_lane_change = getClosestLaneChangeWaypointNumber(cur_lane.waypoints, clst_wp);
   if (num_lane_change < 0 || num_lane_change >= static_cast<int32_t>(cur_lane.waypoints.size()))
@@ -221,12 +223,13 @@ void LaneSelectNode::createLaneForChange()
 
   double dt = getTwoDimensionalDistance(cur_lane.waypoints.at(num_lane_change).pose.pose.position,
                                         cur_lane.waypoints.at(clst_wp).pose.pose.position);
-  double dt_by_vel = std::max(fabs(current_velocity_.twist.linear.x * lane_change_target_ratio_), lane_change_target_minimum_);
-  autoware_msgs::Lane &nghbr_lane =
+  double dt_by_vel =
+      std::max(fabs(current_velocity_.twist.linear.x * lane_change_target_ratio_), lane_change_target_minimum_);
+  autoware_msgs::Lane& nghbr_lane =
       static_cast<ChangeFlag>(cur_lane.waypoints.at(num_lane_change).change_flag) == ChangeFlag::right ?
           std::get<0>(tuple_vec_.at(right_lane_idx_)) :
           std::get<0>(tuple_vec_.at(left_lane_idx_));
-  const int32_t &nghbr_clst_wp =
+  const int32_t& nghbr_clst_wp =
       static_cast<ChangeFlag>(cur_lane.waypoints.at(num_lane_change).change_flag) == ChangeFlag::right ?
           std::get<1>(tuple_vec_.at(right_lane_idx_)) :
           std::get<1>(tuple_vec_.at(left_lane_idx_));
@@ -247,11 +250,12 @@ void LaneSelectNode::createLaneForChange()
     return;
 
   std::get<0>(lane_for_change_).header.stamp = nghbr_lane.header.stamp;
-  std::vector<autoware_msgs::Waypoint> hermite_wps = generateHermiteCurveForROS(
-      cur_lane.waypoints.at(num_lane_change).pose.pose, nghbr_lane.waypoints.at(target_num).pose.pose,
-      cur_lane.waypoints.at(num_lane_change).twist.twist.linear.x, vlength_hermite_curve_);
+  std::vector<autoware_msgs::Waypoint> hermite_wps =
+      generateHermiteCurveForROS(cur_lane.waypoints.at(num_lane_change).pose.pose,
+                                 nghbr_lane.waypoints.at(target_num).pose.pose,
+                                 cur_lane.waypoints.at(num_lane_change).twist.twist.linear.x, vlength_hermite_curve_);
 
-  for (auto &&el : hermite_wps)
+  for (auto&& el : hermite_wps)
     el.change_flag = cur_lane.waypoints.at(num_lane_change).change_flag;
 
   std::get<0>(lane_for_change_).waypoints.reserve(nghbr_lane.waypoints.size() + hermite_wps.size());
@@ -268,11 +272,10 @@ void LaneSelectNode::createLaneForChange()
   std::copy(itr, nghbr_lane.waypoints.end(), std::back_inserter(std::get<0>(lane_for_change_).waypoints));
 }
 
-
 // Update change flags for each lane at the corresponding closest waypoint.
 void LaneSelectNode::updateChangeFlag()
 {
-  for (auto &el : tuple_vec_)
+  for (auto& el : tuple_vec_)
   {
     std::get<2>(el) = (std::get<1>(el) != -1) ?
                           static_cast<ChangeFlag>(std::get<0>(el).waypoints.at(std::get<1>(el)).change_flag) :
@@ -304,15 +307,16 @@ void LaneSelectNode::changeLane()
 
 bool LaneSelectNode::updateClosestWaypointNumberForEachLane()
 {
-  for (auto &el : tuple_vec_)
+  for (auto& el : tuple_vec_)
   {
-    std::get<1>(el) = getClosestWaypointNumber(std::get<0>(el), current_pose_.pose, current_velocity_.twist,
-                                               std::get<1>(el), distance_threshold_, search_closest_waypoint_minimum_dt_);
+    std::get<1>(el) =
+        getClosestWaypointNumber(std::get<0>(el), current_pose_.pose, current_velocity_.twist, std::get<1>(el),
+                                 distance_threshold_, search_closest_waypoint_minimum_dt_);
   }
 
   // confirm if all closest waypoint numbers are -1. If so, output warning
   int32_t accum = 0;
-  for (const auto &el : tuple_vec_)
+  for (const auto& el : tuple_vec_)
   {
     accum += std::get<1>(el);
   }
@@ -342,7 +346,7 @@ int32_t LaneSelectNode::findMostClosestLane(const std::vector<uint32_t> idx_vec,
 {
   std::vector<double> dist_vec;
   dist_vec.reserve(idx_vec.size());
-  for (const auto &el : idx_vec)
+  for (const auto& el : idx_vec)
   {
     int32_t closest_number = std::get<1>(tuple_vec_.at(el));
     if (closest_number == -1)
@@ -362,7 +366,7 @@ int32_t LaneSelectNode::findMostClosestLane(const std::vector<uint32_t> idx_vec,
 void LaneSelectNode::findNeighborLanes()
 {
   int32_t current_closest_num = std::get<1>(tuple_vec_.at(current_lane_idx_));
-  const geometry_msgs::Pose &current_closest_pose =
+  const geometry_msgs::Pose& current_closest_pose =
       std::get<0>(tuple_vec_.at(current_lane_idx_)).waypoints.at(current_closest_num).pose.pose;
 
   std::vector<uint32_t> left_lane_idx_vec;
@@ -377,7 +381,7 @@ void LaneSelectNode::findNeighborLanes()
 
     // Get the closest waypoint on the target lane.
     int32_t target_num = std::get<1>(tuple_vec_.at(i));
-    const geometry_msgs::Point &target_p = std::get<0>(tuple_vec_.at(i)).waypoints.at(target_num).pose.pose.position;
+    const geometry_msgs::Point& target_p = std::get<0>(tuple_vec_.at(i)).waypoints.at(target_num).pose.pose.position;
 
     geometry_msgs::Point converted_p = convertPointIntoRelativeCoordinate(target_p, current_closest_pose);
 
@@ -428,7 +432,7 @@ visualization_msgs::Marker LaneSelectNode::createCurrentLaneMarker()
   color_current.a = 1.0;
   marker.color = color_current;
 
-  for (const auto &em : std::get<0>(tuple_vec_.at(current_lane_idx_)).waypoints)
+  for (const auto& em : std::get<0>(tuple_vec_.at(current_lane_idx_)).waypoints)
     marker.points.push_back(em.pose.pose.position);
 
   return marker;
@@ -462,10 +466,10 @@ visualization_msgs::Marker LaneSelectNode::createRightLaneMarker()
   color_neighbor_change.g = 1.0;
   color_neighbor_change.a = 1.0;
 
-  const ChangeFlag &change_flag = std::get<2>(tuple_vec_.at(current_lane_idx_));
+  const ChangeFlag& change_flag = std::get<2>(tuple_vec_.at(current_lane_idx_));
   marker.color = change_flag == ChangeFlag::right ? color_neighbor_change : color_neighbor;
 
-  for (const auto &em : std::get<0>(tuple_vec_.at(right_lane_idx_)).waypoints)
+  for (const auto& em : std::get<0>(tuple_vec_.at(right_lane_idx_)).waypoints)
     marker.points.push_back(em.pose.pose.position);
 
   return marker;
@@ -499,10 +503,10 @@ visualization_msgs::Marker LaneSelectNode::createLeftLaneMarker()
   color_neighbor_change.g = 1.0;
   color_neighbor_change.a = 1.0;
 
-  const ChangeFlag &change_flag = std::get<2>(tuple_vec_.at(current_lane_idx_));
+  const ChangeFlag& change_flag = std::get<2>(tuple_vec_.at(current_lane_idx_));
   marker.color = change_flag == ChangeFlag::left ? color_neighbor_change : color_neighbor;
 
-  for (const auto &em : std::get<0>(tuple_vec_.at((left_lane_idx_))).waypoints)
+  for (const auto& em : std::get<0>(tuple_vec_.at((left_lane_idx_))).waypoints)
     marker.points.push_back(em.pose.pose.position);
 
   return marker;
@@ -535,7 +539,7 @@ visualization_msgs::Marker LaneSelectNode::createChangeLaneMarker()
   color_current.a = 1.0;
 
   marker.color = current_state_ == "LANE_CHANGE" ? color_current : color;
-  for (const auto &em : std::get<0>(lane_for_change_).waypoints)
+  for (const auto& em : std::get<0>(lane_for_change_).waypoints)
     marker.points.push_back(em.pose.pose.position);
 
   return marker;
@@ -583,7 +587,7 @@ void LaneSelectNode::publishVisualizer()
   vis_pub1_.publish(marker_array);
 }
 
-void LaneSelectNode::publishLane(const autoware_msgs::Lane &lane)
+void LaneSelectNode::publishLane(const autoware_msgs::Lane& lane)
 {
   // publish global lane
   pub1_.publish(lane);
@@ -665,7 +669,7 @@ void LaneSelectNode::callbackFromStopArray(const autoware_msgs::LaneArrayConstPt
 }
 
 void LaneSelectNode::callbackFromPoseTwistStamped(const geometry_msgs::PoseStampedConstPtr& pose_msg,
-                                  const geometry_msgs::TwistStampedConstPtr& twist_msg)
+                                                  const geometry_msgs::TwistStampedConstPtr& twist_msg)
 {
   current_pose_ = *pose_msg;
   is_current_pose_subscribed_ = true;
@@ -674,7 +678,7 @@ void LaneSelectNode::callbackFromPoseTwistStamped(const geometry_msgs::PoseStamp
   is_current_velocity_subscribed_ = true;
 }
 
-void LaneSelectNode::callbackFromDecisionMakerState(const std_msgs::StringConstPtr &msg)
+void LaneSelectNode::callbackFromDecisionMakerState(const std_msgs::StringConstPtr& msg)
 {
   if (msg->data.find("ChangeTo") != std::string::npos)
   {
@@ -687,7 +691,7 @@ void LaneSelectNode::callbackFromDecisionMakerState(const std_msgs::StringConstP
   is_current_state_subscribed_ = true;
 }
 
-void LaneSelectNode::callbackFromConfig(const autoware_config_msgs::ConfigLaneSelectConstPtr &msg)
+void LaneSelectNode::callbackFromConfig(const autoware_config_msgs::ConfigLaneSelectConstPtr& msg)
 {
   distance_threshold_ = msg->distance_threshold_neighbor_lanes;
   lane_change_interval_ = msg->lane_change_interval;
@@ -703,14 +707,14 @@ void LaneSelectNode::run()
 }
 
 // distance between target 1 and target2 in 2-D
-double getTwoDimensionalDistance(const geometry_msgs::Point &target1, const geometry_msgs::Point &target2)
+double getTwoDimensionalDistance(const geometry_msgs::Point& target1, const geometry_msgs::Point& target2)
 {
   double distance = sqrt(pow(target1.x - target2.x, 2) + pow(target1.y - target2.y, 2));
   return distance;
 }
 
-geometry_msgs::Point convertPointIntoRelativeCoordinate(const geometry_msgs::Point &input_point,
-                                                        const geometry_msgs::Pose &pose)
+geometry_msgs::Point convertPointIntoRelativeCoordinate(const geometry_msgs::Point& input_point,
+                                                        const geometry_msgs::Pose& pose)
 {
   tf::Transform inverse;
   tf::poseMsgToTF(pose, inverse);
@@ -724,8 +728,8 @@ geometry_msgs::Point convertPointIntoRelativeCoordinate(const geometry_msgs::Poi
   return tf_point_msg;
 }
 
-geometry_msgs::Point convertPointIntoWorldCoordinate(const geometry_msgs::Point &input_point,
-                                                     const geometry_msgs::Pose &pose)
+geometry_msgs::Point convertPointIntoWorldCoordinate(const geometry_msgs::Point& input_point,
+                                                     const geometry_msgs::Pose& pose)
 {
   tf::Transform inverse;
   tf::poseMsgToTF(pose, inverse);
@@ -739,7 +743,7 @@ geometry_msgs::Point convertPointIntoWorldCoordinate(const geometry_msgs::Point 
   return tf_point_msg;
 }
 
-double getRelativeAngle(const geometry_msgs::Pose &waypoint_pose, const geometry_msgs::Pose &current_pose)
+double getRelativeAngle(const geometry_msgs::Pose& waypoint_pose, const geometry_msgs::Pose& current_pose)
 {
   tf::Vector3 x_axis(1, 0, 0);
   tf::Transform waypoint_tfpose;
@@ -753,8 +757,8 @@ double getRelativeAngle(const geometry_msgs::Pose &waypoint_pose, const geometry
 }
 
 // get closest waypoint from current pose
-int32_t getClosestWaypointNumber(const autoware_msgs::Lane &current_lane, const geometry_msgs::Pose &current_pose,
-                                 const geometry_msgs::Twist &current_velocity, const int32_t previous_number,
+int32_t getClosestWaypointNumber(const autoware_msgs::Lane& current_lane, const geometry_msgs::Pose& current_pose,
+                                 const geometry_msgs::Twist& current_velocity, const int32_t previous_number,
                                  const double distance_threshold, const int search_closest_waypoint_minimum_dt)
 {
   if (current_lane.waypoints.size() < 2)
@@ -784,7 +788,7 @@ int32_t getClosestWaypointNumber(const autoware_msgs::Lane &current_lane, const 
   for (uint32_t i = range_min; i <= range_max; i++)
   {
     geometry_msgs::Point converted_p =
-      convertPointIntoRelativeCoordinate(current_lane.waypoints.at(i).pose.pose.position, current_pose);
+        convertPointIntoRelativeCoordinate(current_lane.waypoints.at(i).pose.pose.position, current_pose);
     double angle = getRelativeAngle(current_lane.waypoints.at(i).pose.pose, current_pose);
     if (converted_p.x * sgn > 0 && angle < 90)
     {
@@ -797,10 +801,10 @@ int32_t getClosestWaypointNumber(const autoware_msgs::Lane &current_lane, const 
 
   std::vector<double> dist_vec;
   dist_vec.reserve(idx_vec.size());
-  for (const auto &el : idx_vec)
+  for (const auto& el : idx_vec)
   {
-    double distance = getTwoDimensionalDistance(
-      current_pose.position, current_lane.waypoints.at(el).pose.pose.position);
+    double distance =
+        getTwoDimensionalDistance(current_pose.position, current_lane.waypoints.at(el).pose.pose.position);
     dist_vec.push_back(distance);
   }
 
@@ -817,7 +821,7 @@ int32_t getClosestWaypointNumber(const autoware_msgs::Lane &current_lane, const 
 
 // let the linear equation be "ax + by + c = 0"
 // if there are two points (x1,y1) , (x2,y2), a = "y2-y1, b = "(-1) * x2 - x1" ,c = "(-1) * (y2-y1)x1 + (x2-x1)y1"
-bool getLinearEquation(geometry_msgs::Point start, geometry_msgs::Point end, double *a, double *b, double *c)
+bool getLinearEquation(geometry_msgs::Point start, geometry_msgs::Point end, double* a, double* b, double* c)
 {
   //(x1, y1) = (start.x, star.y), (x2, y2) = (end.x, end.y)
   double sub_x = fabs(start.x - end.x);
@@ -843,4 +847,4 @@ double getDistanceBetweenLineAndPoint(geometry_msgs::Point point, double a, doub
   return d;
 }
 
-}  // lane_planner
+}  // namespace lane_planner

--- a/lane_planner/nodes/lane_select/lane_select_core.cpp
+++ b/lane_planner/nodes/lane_select/lane_select_core.cpp
@@ -560,6 +560,7 @@ visualization_msgs::Marker LaneSelectNode::createClosestWaypointsMarker()
   marker.type = visualization_msgs::Marker::POINTS;
   marker.action = visualization_msgs::Marker::ADD;
   marker.scale.x = 0.5;
+  marker.scale.y = 0.5;
   marker.color = color_closest_wp;
 
   marker.points.reserve(tuple_vec_.size());


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
- format ```lane_select_core.cpp```
- ```stop_waypoints_array```が更新された際に```base_waypoints```が更新されるように修正
- ```lane_select_marker```で```visualization_msgs::Marker::POINTS```のサイズ指定が不正だったため修正

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #16

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
- outdoor_navigation toolsのlaunchで検証する場合、judge_stopline.py、judge_endpoint.pyを使用している箇所をコメントアウト（これがあるとbase_waypointsのtwistが0でないのに止まる）して実行
- rqtなどで```/light_color_managed```をパブリッシュし、0のときは停止線で停止、1のときは通過する（デフォルトは通過）
- ```/light_color_managed```によらずゴール地点では停止する

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
