### PR TITLE
Add search_waypoints_min param

### DIFF
--- a/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
+++ b/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
@@ -60,21 +60,22 @@ private:
   ros::Subscriber closest_waypoint_sub_;
   ros::Subscriber obstacle_waypoint_sub_;
   ros::Subscriber state_sub_;
-  ros::Rate *rate_;
+  ros::Rate* rate_;
   ros::Timer timer_;
   tf::TransformListener tf_listener_;
 
   // params
-  int safety_waypoints_size_;   // output waypoint size [-]
-  double update_rate_;          // publishing rate [Hz]
+  int safety_waypoints_size_;  // output waypoint size [-]
+  double update_rate_;         // publishing rate [Hz]
 
-  bool enable_avoidance_;           // enable avoidance mode
-  double avoid_waypoints_velocity_; // constant velocity on planned waypoints [km/h]
-  double avoid_start_velocity_;     // self velocity for staring avoidance behavior [km/h]
-  double replan_interval_;          // replan interval for avoidance planning [Hz]
-  int search_waypoints_size_;       // range of waypoints for incremental search [-]
-  int search_waypoints_delta_;      // skipped waypoints for incremental search [-]
-  int closest_search_size_;         // search closest waypoint around your car [-]
+  bool enable_avoidance_;            // enable avoidance mode
+  double avoid_waypoints_velocity_;  // constant velocity on planned waypoints [km/h]
+  double avoid_start_velocity_;      // self velocity for staring avoidance behavior [km/h]
+  double replan_interval_;           // replan interval for avoidance planning [Hz]
+  int search_waypoints_size_;        // range of waypoints for incremental search [-]
+  int search_waypoints_delta_;       // skipped waypoints for incremental search [-]
+  int search_waypoints_min_;         // Points closer than this index are not searched. [-]
+  int closest_search_size_;          // search closest waypoint around your car [-]
   int stopline_ahead_num_;
 
   // classes

--- a/waypoint_planner/src/astar_avoid/astar_avoid.cpp
+++ b/waypoint_planner/src/astar_avoid/astar_avoid.cpp
@@ -16,9 +16,7 @@
 
 #include "waypoint_planner/astar_avoid/astar_avoid.h"
 
-AstarAvoid::AstarAvoid()
-  : nh_()
-  , private_nh_("~")
+AstarAvoid::AstarAvoid() : nh_(), private_nh_("~")
 {
   private_nh_.param<int>("safety_waypoints_size", safety_waypoints_size_, 100);
   private_nh_.param<double>("update_rate", update_rate_, 10.0);
@@ -29,6 +27,7 @@ AstarAvoid::AstarAvoid()
   private_nh_.param<double>("replan_interval", replan_interval_, 2.0);
   private_nh_.param<int>("search_waypoints_size", search_waypoints_size_, 50);
   private_nh_.param<int>("search_waypoints_delta", search_waypoints_delta_, 2);
+  private_nh_.param<int>("search_waypoints_min", search_waypoints_min_, 0);
   private_nh_.param<int>("closest_search_size", closest_search_size_, 30);
   private_nh_.param<int>("stopline_ahead_num", stopline_ahead_num_, 1);
 
@@ -281,7 +280,7 @@ bool AstarAvoid::planAvoidWaypoints(int& end_of_avoid_index)
     // Note: obstacle_waypoint_index_ is supposed to be relative to base_waypoint_index_.
     //       However, obstacle_waypoint_index_ is published by velocity_set node. The astar_avoid and velocity_set
     //       should be combined together to prevent this kind of inconsistency.
-    int goal_waypoint_index = base_waypoint_index_ + obstacle_waypoint_index_ + i;
+    int goal_waypoint_index = base_waypoint_index_ + obstacle_waypoint_index_ + search_waypoints_min_ + i;
     if (goal_waypoint_index >= static_cast<int>(base_waypoints_.waypoints.size()))
     {
       break;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
ゴール地点の探索区間を前方にオフセットするパラメータを追加
詳細はissueを参照してください
変数名で他に案があれば意見ほしいです

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #25
