### PR TITLE
Enable curve_weight

### DIFF
--- a/astar_search/src/astar_search.cpp
+++ b/astar_search/src/astar_search.cpp
@@ -385,7 +385,7 @@ bool AstarSearch::search()
       if (state.back != current_an->back)
         move_cost *= reverse_weight_;
       // Increase curve cost
-      double curve_cost_scale = 1.0 + (fabs(state.rotation) * (curve_weight_ - 1.0));
+      double curve_cost_scale = std::max(0.0, 1.0 + (fabs(state.rotation) * (curve_weight_ - 1.0)));
       move_cost *= curve_cost_scale;
 
       // Calculate index of the next state

--- a/astar_search/src/astar_search.cpp
+++ b/astar_search/src/astar_search.cpp
@@ -384,6 +384,9 @@ bool AstarSearch::search()
       // Increase reverse cost
       if (state.back != current_an->back)
         move_cost *= reverse_weight_;
+      // Increase curve cost
+      double curve_cost_scale = 1.0 + (fabs(state.rotation) * (curve_weight_ - 1.0));
+      move_cost *= curve_cost_scale;
 
       // Calculate index of the next state
       SimpleNode next_sn;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
asterの探索で角度変化に比例してcostを追加。
これによりノードの候補が複数ある際に角度変化の小さいノードから探索するようになります。

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #29

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
