### PR TITLE
Feature/fill waypoints nearest area

### DIFF
--- a/waypoint_planner/include/waypoint_planner/velocity_set/velocity_set_path.h
+++ b/waypoint_planner/include/waypoint_planner/velocity_set/velocity_set_path.h
@@ -47,6 +47,8 @@ class VelocitySetPath
   void setTemporalWaypoints(int temporal_waypoints_size, int closest_waypoint, geometry_msgs::PoseStamped control_pose);
   void initializeNewWaypoints();
   void resetFlag();
+  void setPrevWaypoints(const autoware_msgs::Lane& lane);
+  void setNewWaypoints(const autoware_msgs::Lane& lane);
 
   // ROS Callbacks
   void waypointsCallback(const autoware_msgs::LaneConstPtr& msg);

--- a/waypoint_planner/src/velocity_set/velocity_set_path.cpp
+++ b/waypoint_planner/src/velocity_set/velocity_set_path.cpp
@@ -237,3 +237,13 @@ void VelocitySetPath::currentVelocityCallback(const geometry_msgs::TwistStampedC
 {
   current_vel_ = msg->twist.linear.x;
 }
+
+void VelocitySetPath::setPrevWaypoints(const autoware_msgs::Lane& lane)
+{
+  original_waypoints_ = lane;
+}
+
+void VelocitySetPath::setNewWaypoints(const autoware_msgs::Lane& lane)
+{
+  updated_waypoints_ = lane;
+}

--- a/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
+++ b/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
@@ -650,9 +650,10 @@ int fillWaypointsNearestArea(VelocitySetPath& vs_path, const autoware_msgs::Lane
     new_waypoint.pose.pose.position.y = next_waypoint.pose.pose.position.y + dy / distance * cumulative_distance;
     new_waypoint.pose.pose.position.z = next_waypoint.pose.pose.position.z + dz / distance * cumulative_distance;
     lane_update.waypoints.push_back(new_waypoint);
-    std::reverse(lane_update.waypoints.begin(), lane_update.waypoints.end());
     cumulative_distance += distance_per_waypoint;
   }
+
+  std::reverse(lane_update.waypoints.begin(), lane_update.waypoints.end());
 
   lane_update.waypoints.insert(lane_update.waypoints.end(), lane.waypoints.begin(), lane.waypoints.end());
 

--- a/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
+++ b/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
@@ -638,18 +638,18 @@ int fillWaypointsNearestArea(VelocitySetPath& vs_path, const autoware_msgs::Lane
   lane_update.lane_id = lane.lane_id;
   lane_update.header = lane.header;
 
-  double dx = next_waypoint.pose.pose.position.x - pose.pose.position.x;
-  double dy = next_waypoint.pose.pose.position.y - pose.pose.position.y;
-  double dz = next_waypoint.pose.pose.position.z - pose.pose.position.z;
+  double dx = pose.pose.position.x - next_waypoint.pose.pose.position.x;
+  double dy = pose.pose.position.y - next_waypoint.pose.pose.position.y;
+  double dz = pose.pose.position.z - next_waypoint.pose.pose.position.z;
   double distance = sqrt(pow(dx, 2) + pow(dy, 2) + pow(dz, 2));
   double cumulative_distance = distance_per_waypoint;
 
   while (cumulative_distance < distance)
   {
-    new_waypoint.pose.pose.position.x = pose.pose.position.x + dx / distance * cumulative_distance;
-    new_waypoint.pose.pose.position.y = pose.pose.position.y + dy / distance * cumulative_distance;
-    new_waypoint.pose.pose.position.z = pose.pose.position.z + dz / distance * cumulative_distance;
-    lane_update.waypoints.push_back(new_waypoint);
+    new_waypoint.pose.pose.position.x = next_waypoint.pose.pose.position.x + dx / distance * cumulative_distance;
+    new_waypoint.pose.pose.position.y = next_waypoint.pose.pose.position.y + dy / distance * cumulative_distance;
+    new_waypoint.pose.pose.position.z = next_waypoint.pose.pose.position.z + dz / distance * cumulative_distance;
+    lane_update.waypoints.insert(lane_update.waypoints.begin(), new_waypoint);
     cumulative_distance += distance_per_waypoint;
   }
 

--- a/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
+++ b/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
@@ -628,6 +628,9 @@ void binMapCallback(const autoware_lanelet2_msgs::MapBin& msg)
 // fill waypoints from the current position to the nearest point
 int fillWaypointsNearestArea(VelocitySetPath& vs_path, const autoware_msgs::Lane& lane, const geometry_msgs::PoseStamped& pose, const double distance_per_waypoint)
 {
+  if(distance_per_waypoint <= 0)
+    return 0;
+
   autoware_msgs::Waypoint next_waypoint = lane.waypoints.at(0);
   autoware_msgs::Waypoint new_waypoint;
   autoware_msgs::Lane lane_update;

--- a/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
+++ b/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
@@ -649,7 +649,8 @@ int fillWaypointsNearestArea(VelocitySetPath& vs_path, const autoware_msgs::Lane
     new_waypoint.pose.pose.position.x = next_waypoint.pose.pose.position.x + dx / distance * cumulative_distance;
     new_waypoint.pose.pose.position.y = next_waypoint.pose.pose.position.y + dy / distance * cumulative_distance;
     new_waypoint.pose.pose.position.z = next_waypoint.pose.pose.position.z + dz / distance * cumulative_distance;
-    lane_update.waypoints.insert(lane_update.waypoints.begin(), new_waypoint);
+    lane_update.waypoints.push_back(new_waypoint);
+    std::reverse(lane_update.waypoints.begin(), lane_update.waypoints.end());
     cumulative_distance += distance_per_waypoint;
   }
 

--- a/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
+++ b/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
@@ -626,7 +626,7 @@ void binMapCallback(const autoware_lanelet2_msgs::MapBin& msg)
 }
 
 // fill waypoints from the current position to the nearest point
-int fillWaypointsNearestArea(VelocitySetPath& vs_path, const autoware_msgs::Lane& lane, const geometry_msgs::PoseStamped& pose)
+int fillWaypointsNearestArea(VelocitySetPath& vs_path, const autoware_msgs::Lane& lane, const geometry_msgs::PoseStamped& pose, const double distance_per_waypoint)
 {
   autoware_msgs::Waypoint next_waypoint = lane.waypoints.at(0);
   autoware_msgs::Waypoint new_waypoint;
@@ -646,7 +646,6 @@ int fillWaypointsNearestArea(VelocitySetPath& vs_path, const autoware_msgs::Lane
   if (distance < 0.2)
     return 0;
 
-  double distance_per_waypoint = 0.1;
   num_waypoints = static_cast<int>(distance / distance_per_waypoint) + 1;
 
   for (int i = 1; i < num_waypoints - 1; i++)
@@ -686,6 +685,7 @@ int main(int argc, char** argv)
   std::string points_topic;
   int deceleration_search_distance;
   int stop_search_distance;
+  double fill_waypoints_interval;
 
   private_rosnode.param<bool>("use_crosswalk_detection", use_crosswalk_detection, true);
   private_rosnode.param<bool>("enable_multiple_crosswalk_detection", enable_multiple_crosswalk_detection, true);
@@ -693,6 +693,7 @@ int main(int argc, char** argv)
   private_rosnode.param<std::string>("points_topic", points_topic, "points_lanes");
   private_rosnode.param<int>("deceleration_search_distance", deceleration_search_distance, 30);
   private_rosnode.param<int>("stop_search_distance", stop_search_distance, 60);
+  private_rosnode.param<double>("fill_waypoints_interval", fill_waypoints_interval, 0.1);
 
   VelocitySetPath vs_path;
   VelocitySetInfo vs_info;
@@ -752,7 +753,7 @@ int main(int argc, char** argv)
       continue;
     }
 
-    int num_filled_waypoints = fillWaypointsNearestArea(vs_path, vs_path.getPrevWaypoints(), vs_info.getControlPose());
+    int num_filled_waypoints = fillWaypointsNearestArea(vs_path, vs_path.getPrevWaypoints(), vs_info.getControlPose(), fill_waypoints_interval);
 
     int detection_waypoint = -1;
     lanelet::ConstLanelets closest_crosswalks;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
- 以下のissueに関連して、最初のwaypointに乗るまで障害物を無視する問題を修正しました。
https://github.com/sbgisen/wheeltec_robot/issues/277
<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

<!-- 変更の詳細 -->
## Detail
- ロボットの現在地からvelocity_setで購読する`/safety_waypoints`の最初のウェイポイントまでの間にウェイポイントを追加する処理を追加しました。この追加により、最初のwaypointに乗るまでの間に障害物がある場合でも、減速および停止することが出来ます。
- ベースのウェイポイントの間隔がwaypoint_loader側で`resample_interval`としてパラメータが用意されているので、ここで新しく追加するウェイポイントの間隔も`fill_waypoints_interval`としてパラメータ化しました。

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact
- この変更により、パラメータの追加が発生するので、wheeltec_robot側にもパラメータの追加に関するPRを出します。
<!-- どのような動作検証を行ったか -->
## Test
* [x] 竹芝オフィスの一周経路でのナビゲーションで動作確認

## Attention
@gakutasu  
私が対応した[autoware_ai_planning](https://github.com/sbgisen/autoware_ai_planning)における2023/07/03に実施した走行までの修正内容はこのPRで最後になります。
