### PR TITLE
Smoothly decelerate

### DIFF
--- a/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
+++ b/waypoint_planner/include/waypoint_planner/astar_avoid/astar_avoid.h
@@ -76,6 +76,7 @@ private:
   int search_waypoints_delta_;      // skipped waypoints for incremental search [-]
   int closest_search_size_;         // search closest waypoint around your car [-]
   int stopline_ahead_num_;
+  double decel_limit_; // deceleration limit [m/s^2]
 
   // classes
   AstarSearch astar_;


### PR DESCRIPTION
Merge master into noetic-devel<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

回避経路から元々の経路に接続時に、急減速させるような速度司令を与えないように
スムーズな速度接続を実現
ただし、元々の経路のほうが早い速度を指定していて加速が必要な場合に関しては、
回避経路中に回避経路の定常速度を超えてしまうのも良くないと思うので除いています

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- ref #7 
- ref https://github.com/sbgisen/wheeltec_robot/issues/319

<!-- 変更の詳細 -->
## Detail

停止線手前に回避経路が作れないときは止まる
![Screenshot from 2023-10-04 13-35-33](https://github.com/sbgisen/autoware_ai_planning/assets/13605820/20784e62-f4fd-4b6c-811a-a723a4c581e8)

停止線手前の減速領域で回避経路のほうが早い場合はなめらかに減速
![Screenshot from 2023-10-04 13-36-18](https://github.com/sbgisen/autoware_ai_planning/assets/13605820/102b34ec-a329-49a8-8bff-f4bf73815087)


加速が必要なときはそのまま
![Screenshot from 2023-10-04 13-07-51](https://github.com/sbgisen/autoware_ai_planning/assets/13605820/0e74cfd9-2135-4172-a1ae-4b2652e4e20e)


<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

実機での`decel_limit`の調整が必要です。

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
