### PR TITLE
Stop moving if aster avoid couldn't find any path

### DIFF
--- a/waypoint_planner/src/astar_avoid/astar_avoid.cpp
+++ b/waypoint_planner/src/astar_avoid/astar_avoid.cpp
@@ -483,8 +483,8 @@ int AstarAvoid::updateClosestWaypoint(const autoware_msgs::Lane& waypoints, cons
   // search in all waypoints if lane_select judges you're not on waypoints
   if (previous_index == -1)
   {
-    ROS_WARN("[AstarAvoid::updateClosestWaypoint] previous_index == -1, -> RELAYING");
-    state_ = AstarAvoid::STATE::RELAYING;
+    ROS_WARN("[AstarAvoid::updateClosestWaypoint] previous_index == -1, -> STOPPING");
+    state_ = AstarAvoid::STATE::STOPPING;
     select_way_ = AstarAvoid::STATE::RELAYING;
     next_index = closest_waypoint_index_;
     base_waypoint_index_ = closest_waypoint_index_;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
Aster avoidで回避経路が見つからなかった際の遷移先を`RELAYING`から`STOPPING`に変更

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #41
