### PR TITLE
Feature/interpolate on xy

### DIFF
--- a/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
+++ b/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
@@ -644,7 +644,7 @@ int fillWaypointsNearestArea(VelocitySetPath& vs_path, const autoware_msgs::Lane
   double dx = pose.pose.position.x - next_waypoint.pose.pose.position.x;
   double dy = pose.pose.position.y - next_waypoint.pose.pose.position.y;
   double dz = pose.pose.position.z - next_waypoint.pose.pose.position.z;
-  double distance = sqrt(pow(dx, 2) + pow(dy, 2) + pow(dz, 2));
+  double distance = sqrt(pow(dx, 2) + pow(dy, 2));
   double cumulative_distance = distance_per_waypoint;
 
   while (cumulative_distance < distance)

--- a/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
+++ b/waypoint_planner/src/velocity_set_lanelet2/velocity_set_lanelet2.cpp
@@ -643,15 +643,14 @@ int fillWaypointsNearestArea(VelocitySetPath& vs_path, const autoware_msgs::Lane
 
   double dx = pose.pose.position.x - next_waypoint.pose.pose.position.x;
   double dy = pose.pose.position.y - next_waypoint.pose.pose.position.y;
-  double dz = pose.pose.position.z - next_waypoint.pose.pose.position.z;
-  double distance = sqrt(pow(dx, 2) + pow(dy, 2));
+  double distance = hypot(dx, dy);
   double cumulative_distance = distance_per_waypoint;
 
   while (cumulative_distance < distance)
   {
     new_waypoint.pose.pose.position.x = next_waypoint.pose.pose.position.x + dx / distance * cumulative_distance;
     new_waypoint.pose.pose.position.y = next_waypoint.pose.pose.position.y + dy / distance * cumulative_distance;
-    new_waypoint.pose.pose.position.z = next_waypoint.pose.pose.position.z + dz / distance * cumulative_distance;
+    new_waypoint.pose.pose.position.z = next_waypoint.pose.pose.position.z;
     lane_update.waypoints.push_back(new_waypoint);
     cumulative_distance += distance_per_waypoint;
   }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
ロボットの現在位置からwaypointへの軌跡を補間する際の間隔をxy基準にし、z方向にwaypointの数が増えることを防ぎます

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #40 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
